### PR TITLE
Add the spectral method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,19 @@
 name = "MeanFieldGraph"
 uuid = "f3c20582-38a4-43ca-95fd-b3c95fb7ac78"
-authors = ["Julien Chevallier"]
 version = "0.2.0"
+authors = ["Julien Chevallier"]
 
 [deps]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [compat]
 Clustering = "0.15.7"
 Distributions = "0.25"
+KrylovKit = "0.10.2"
 LinearAlgebra = "1"
 Plots = "1"
 julia = "1.6"

--- a/src/MeanFieldGraph.jl
+++ b/src/MeanFieldGraph.jl
@@ -4,6 +4,7 @@ using Clustering: Clustering, ClusteringResult, assignments, counts, kmeans, hcl
 using Distributions: Distributions, Bernoulli, DiscreteUniform, fit, mean
 using LinearAlgebra: LinearAlgebra, I, transpose
 using Plots: Plots, heatmap, palette, plot
+using KrylovKit: KrylovKit, eigsolve
 
 export MarkovChainModel, DiscreteTimeData, MarkovChainConnectivity
 export mvw, mvw_inf

--- a/src/classification.jl
+++ b/src/classification.jl
@@ -4,11 +4,25 @@
 Estimates the two underlying communities (one excitatory and one inhibitory) from the data set `data`. It returns a `Vector{Bool}` where the `true` coordinates correspond to excitatory components and `false` coordinates correspond to inhibitory components.
 
 # Keyword arguments
+    - `method::Symbol`: the method applied to estimate the covariance vector σ. Valid choices are: `:aggregated` (the default) and `:spectral`.
     - `clustering::Symbol`: the clustering method applied to the estimated covariance vector. Valid choices are: `:kmeans` (the default) and `:hclust`.
 """
-function classification(data::DiscreteTimeData; clustering::Symbol=:kmeans)::Vector{Bool}
-    σ̂ = covariance_vector(data)
+function classification(
+    data::DiscreteTimeData; method::Symbol=:aggregated, clustering::Symbol=:kmeans
+)::Vector{Bool}
 
+    # Estimation of the covariance vector σ
+    if method == :aggregated
+        σ̂ = covariance_vector(data)
+    elseif method == :spectral
+        Σ̂ = covariance_matrix(data)
+        _, vecs = eigsolve(transpose(Σ̂) * Σ̂)
+        σ̂ = vecs[1]
+    else
+        throw(ArgumentError("Unsupported method $method"))
+    end
+
+    # Clustering based on the estimated σ̂
     if clustering == :kmeans
         initialisation = [argmin(σ̂), argmax(σ̂)]
         output = cluster2bool(kmeans(transpose(σ̂), 2; init=initialisation))
@@ -35,6 +49,20 @@ function covariance_vector(data::DiscreteTimeData)::Vector{Float64}
     # It is not written exactly like the definition in the paper but it is an equivalent formula.
 
     return output[:, 1]
+end
+
+function covariance_matrix(data::DiscreteTimeData)::Matrix{Float64}
+    X = data.X
+    N, T = size(data)
+    Z = sum(X; dims=2)
+
+    s = zeros((N, N))
+    for t in 1:(T - 1)
+        s += @views(X[:, t + 1] * transpose(X[:, t]))
+    end
+    output = s / (T - 1) - Z * transpose(Z) / T^2
+
+    return output
 end
 
 # Auxiliary functions

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,9 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/classification.jl
+++ b/test/classification.jl
@@ -1,15 +1,34 @@
 @testset "classification.jl" begin
+    data = DiscreteTimeData([
+        [1 0 0]
+        [0 1 1]
+        [1 0 0]
+        [1 1 0]
+    ])
+
     @test begin
-        data = DiscreteTimeData([
-            [1 0 0]
-            [0 1 1]
-            [1 0 0]
-            [1 1 0]
-        ])
         handcomputation = [
             1 - 2 * 1 / 3, 1 / 2 - 2 * 2 / 3, 1 - 2 * 1 / 3, 3 / 2 - 2 * 2 / 3
         ]
         MF.covariance_vector(data) == handcomputation
+    end
+
+    @test begin
+        handcomputation_Xs =
+            1 / 2 * [
+                [0 + 0 0 + 0 0 + 0 0 + 0]
+                [1 + 0 0 + 1 1 + 0 1 + 1]
+                [0 + 0 0 + 0 0 + 0 0 + 0]
+                [1 + 0 0 + 0 1 + 0 1 + 0]
+            ]
+        handcomputation_Zs =
+            1 / 9 * [
+                [1 * 1 1 * 2 1 * 1 1 * 2]
+                [2 * 1 2 * 2 2 * 1 2 * 2]
+                [1 * 1 1 * 2 1 * 1 1 * 2]
+                [2 * 1 2 * 2 2 * 1 2 * 2]
+            ]
+        MF.covariance_matrix(data) == handcomputation_Xs .- handcomputation_Zs
     end
 
     @test begin
@@ -19,12 +38,23 @@
     end
 
     @test begin
-        data = DiscreteTimeData([
-            [1 0 0]
-            [0 1 1]
-            [1 0 0]
-            [1 1 0]
-        ])
         classification(data) == [true, false, true, true]
+    end
+
+    @testset "covariance matrix and vector" begin
+        for _ in 1:10
+            Tsimu = Int(1e3)
+            N = 100
+            r₊ = rand()
+            excitatory = MF.N2excitatory(N, r₊)
+            β = rand()
+            λ = 0.3 + 0.7 * rand()
+            p = rand()
+            model = MarkovChainModel(β * λ, λ, p)
+            data = rand(model, N, r₊, Tsimu)
+            cov_vec = MeanFieldGraph.covariance_vector(data)
+            cov_mat = MeanFieldGraph.covariance_matrix(data)
+            @test cov_vec ≈ sum(cov_mat; dims=1)[1, :]
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,27 @@
-using MeanFieldGraph
-using Test
-using Distributions, LinearAlgebra
-using Random
+using Aqua
 using Clustering
+using Distributions
+using Documenter
+using JET
+using LinearAlgebra
+using MeanFieldGraph
 import MeanFieldGraph as MF
+using Random
+using Test
 
-@testset "MeanFieldGraph.jl" begin
+@testset verbose = true "MeanFieldGraph.jl" begin
+    @testset "Code quality (Aqua.jl)" begin
+        Aqua.test_all(MeanFieldGraph; ambiguities=false, deps_compat=(; check_extras=false))
+    end
+    @testset "Type stability (JET.jl)" begin
+        # test on 1.11 at a minimum and not on pre-release 
+        if VERSION >= v"1.12" && isempty(VERSION.prerelease)
+            JET.test_package(MeanFieldGraph; target_modules=(MeanFieldGraph,))
+        end
+    end
+    @testset "Doctests" begin
+        doctest(MeanFieldGraph)
+    end
     include("model.jl")
     include("simulate.jl")
     include("estimation.jl")


### PR DESCRIPTION
During the revision of the "Community detection" paper, we came up with a second method called "spectral method". The original one is now called "aggregated".

The main modification from the user side is that `classification` has an additional keyword argument called `method`.